### PR TITLE
set CURRENT_TIMESTAMP to expires default

### DIFF
--- a/config/Migrations/20170907030013_CreateRememberMeTokens.php
+++ b/config/Migrations/20170907030013_CreateRememberMeTokens.php
@@ -38,7 +38,7 @@ class CreateRememberMeTokens extends AbstractMigration
             'null' => false,
         ]);
         $table->addColumn('expires', 'timestamp', [
-            'default' => 'CURRENT_TIMESTAMP',
+            'default' => '0000-00-00 00:00:00',
             'null' => false,
         ]);
 

--- a/config/Migrations/20170907030013_CreateRememberMeTokens.php
+++ b/config/Migrations/20170907030013_CreateRememberMeTokens.php
@@ -38,7 +38,7 @@ class CreateRememberMeTokens extends AbstractMigration
             'null' => false,
         ]);
         $table->addColumn('expires', 'timestamp', [
-            'default' => null,
+            'default' => 'CURRENT_TIMESTAMP',
             'null' => false,
         ]);
 


### PR DESCRIPTION
MySQL@5.7.18で`migrations migrate`したところ
`Syntax error or access violation: 1067 Invalid default value for 'expires'`
と出ました。
timestampに、not null, default nullが許可されないようなのでdefaultに明示的にCURRENT_TIMESTAMPを指定しました。